### PR TITLE
Fixed how to create dirname

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ export default (options: AstroFontsNextOptions): AstroIntegration => {
         init(options.url)
 
         if (command === 'dev') {
-          writeFileSync(join(dirname(new URL(import.meta.url).pathname), './urls.json'), JSON.stringify(urls))
+          writeFileSync(join(dirname(fileURLToPath(import.meta.url)), './urls.json'), JSON.stringify(urls))
 
           injectScript('page', `import devScript from 'astro-fonts-next/dev.js'; devScript()`)
         }

--- a/urls.json
+++ b/urls.json
@@ -1,1 +1,0 @@
-["https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,700;1,400&display=swap"]


### PR DESCRIPTION
## Description

When creating dirname, the method was not cross-platform compatible, so this has been corrected.

Fixed #29 